### PR TITLE
Change Trigger for Speed Up feature 

### DIFF
--- a/ModComponent.cs
+++ b/ModComponent.cs
@@ -252,7 +252,7 @@ public sealed class ModComponent : MonoBehaviour
         _isSaveAnywhere = isSelectPressed && !_wasSelectPressed;
         _wasSelectPressed = isSelectPressed;
         
-        bool isSpeedHackPressed =  (gamepad?.rightTrigger.isPressed ?? false) || GRInputManager.IsKeyPress(Key.T);
+        bool isSpeedHackPressed =  (gamepad?.rightShoulder.isPressed ?? false) || GRInputManager.IsKeyPress(Key.T);
         _speedHackChange = isSpeedHackPressed && !_wasSpeedHackPressed;
         _wasSpeedHackPressed = isSpeedHackPressed;
 

--- a/Patches/SpeedHack.cs
+++ b/Patches/SpeedHack.cs
@@ -30,7 +30,7 @@ public class SpeedHackPatch
                 {
                     InputBinding binding = action.bindings[i];
 
-                    if (binding.path.Contains("/rightTrigger"))
+                    if (binding.path.Contains("/rightShoulder"))
                     {
                         action.ChangeBinding(i).Erase();
                         Plugin.Log.LogInfo($"Removed binding {binding.path} in action '{action.name}' in map '{actionMap.name}'");


### PR DESCRIPTION
Changer the trigger to  for Right Trigger to Right Shoulder / R1
The Right trigger/ r2 can cause accidental confirmation on menus and dialogue when you are disabling or activiting the feature 
and that button is also functions as confirm button by default. 

Examples whe whit has undesirable effect is when the game dialogue presents options. 